### PR TITLE
Update to reset_state to improve API consistency

### DIFF
--- a/crnn/metrics.py
+++ b/crnn/metrics.py
@@ -37,7 +37,7 @@ class SequenceAccuracy(keras.metrics.Metric):
     def result(self):
         return self.count / self.total
 
-    def reset_states(self):
+    def reset_state(self):
         self.count.assign(0)
         self.total.assign(0)
 
@@ -64,6 +64,6 @@ class EditDistance(keras.metrics.Metric):
     def result(self):
         return self.sum_distance / self.total
 
-    def reset_states(self):
+    def reset_state(self):
         self.sum_distance.assign(0)
         self.total.assign(0)


### PR DESCRIPTION
Prevent the following warning in TensorFlow 2.7.0:
```
/home/alwin/PycharmProjects/.../venv/lib/python3.9/site-packages/keras/metrics.py:254: UserWarning: Metric SequenceAccuracy implements a `reset_states()` method; rename it to `reset_state()` (without the final "s"). The name `reset_states()` has been deprecated to improve API consistency.
  warnings.warn('Metric %s implements a `reset_states()` method; rename it '
```